### PR TITLE
fix #149 #60 #58

### DIFF
--- a/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/SmartfoxActivator.kt
+++ b/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/SmartfoxActivator.kt
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.Image
 import org.eclipse.swt.widgets.Display
 import org.eclipse.ui.plugin.AbstractUIPlugin
 import org.osgi.framework.BundleContext
+import java.util.Locale
 
 /**
  * @author caikang
@@ -72,20 +73,22 @@ class SmartfoxActivator : AbstractUIPlugin() {
         return image!!
     }
 
-    val locale: String get() {
-        val lang = preferenceStore.getString(localeKey)
-        return if (lang.isNullOrBlank()) {
-            "zh"
-        } else {
-            lang
+    val locale: String
+        get() {
+            val language = preferenceStore.getString(localeKey)
+            if (language.isNullOrBlank()) {
+                val lang = Locale.getDefault().language
+                return if (lang != Locale.ENGLISH.language && lang != Locale.CHINESE.language) {
+                    Locale.CHINESE.language
+                } else Locale.getDefault().language
+            }
+
+            return language
         }
-    }
 
     fun toggleLocale() {
-        preferenceStore.setValue(localeKey, when (locale) {
-            "en" -> "zh"
-            else -> "en"
-        })
+        val lang = if (Locale.ENGLISH.language == locale) Locale.CHINESE.language else Locale.ENGLISH.language
+        preferenceStore.setValue(localeKey, lang)
     }
 
     fun getRule(rule: String): Rule {

--- a/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/SmartfoxActivator.kt
+++ b/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/SmartfoxActivator.kt
@@ -79,7 +79,7 @@ class SmartfoxActivator : AbstractUIPlugin() {
             if (language.isNullOrBlank()) {
                 val lang = Locale.getDefault().language
                 return if (lang != Locale.ENGLISH.language && lang != Locale.CHINESE.language) {
-                    Locale.CHINESE.language
+                    Locale.ENGLISH.language
                 } else Locale.getDefault().language
             }
 

--- a/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/pmd/rule/MapOrSetKeyShouldOverrideHashCodeEqualsRule.kt
+++ b/eclipse-plugin/com.alibaba.smartfox.eclipse.plugin/src/main/kotlin/com/alibaba/smartfox/eclipse/pmd/rule/MapOrSetKeyShouldOverrideHashCodeEqualsRule.kt
@@ -86,8 +86,12 @@ class MapOrSetKeyShouldOverrideHashCodeEqualsRule : AbstractEclipseRule() {
             }
 
             private fun isOverrideEqualsAndHashCode(genericType: ITypeBinding): Boolean {
-                // skip enum
-                if (genericType.isEnum || genericType.isInterface || genericType.isTypeVariable || genericType.isWildcardType) {
+                val skip = genericType.isEnum || genericType.isInterface || genericType.isArray
+                        || genericType.isTypeVariable || genericType.isWildcardType
+                        || genericType.qualifiedName?.startsWith(skipJdkPackageJava) ?: false
+                        || genericType.qualifiedName?.startsWith(skipJdkPackageJavax) ?: false
+                // skip
+                if (skip) {
                     return true
                 }
 

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/SwitchLanguageAction.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/SwitchLanguageAction.kt
@@ -32,15 +32,12 @@ import com.intellij.openapi.project.DumbAware
  * @date 2017/06/20
  */
 class SwitchLanguageAction : AnAction(), DumbAware {
-    val p3cConfig = P3cConfig::class.java.getService()
+    private val p3cConfig = P3cConfig::class.java.getService()
 
-    val textKey = "com.alibaba.p3c.action.switch_language.text"
+    private val textKey = "com.alibaba.p3c.action.switch_language.text"
 
     override fun actionPerformed(e: AnActionEvent) {
-        p3cConfig.locale = when (p3cConfig.locale) {
-            P3cConfig.localeZh -> P3cConfig.localeEn
-            else -> P3cConfig.localeZh
-        }
+        p3cConfig.toggleLanguage()
         BalloonNotifications.showSuccessNotification(P3cBundle.getMessage("$textKey.success"), e.project,
                 NotificationListener { notification, _ ->
                     notification.expire()

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.StoragePathMacros
 import com.intellij.util.xmlb.XmlSerializerUtil
+import java.util.Locale
 
 /**
  *
@@ -27,8 +28,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
  * @author caikang
  * @date 2017/06/19
  */
-@State(name = "P3cConfig",
-        storages = arrayOf(Storage(file = "${StoragePathMacros.APP_CONFIG}/smartfox/p3c.xml")))
+@State(name = "P3cConfig", storages = arrayOf(Storage(file = "${StoragePathMacros.APP_CONFIG}/smartfox/p3c.xml")))
 class P3cConfig : PersistentStateComponent<P3cConfig> {
     var astCacheTime = 1000L
     var astCacheEnable = true
@@ -38,7 +38,21 @@ class P3cConfig : PersistentStateComponent<P3cConfig> {
 
     var analysisBeforeCheckin = false
 
-    var locale = localeZh
+    var locale: String = ""
+        get() {
+            if (field.isEmpty()) {
+                val lang = Locale.getDefault().language
+                return if (lang != Locale.ENGLISH.language && lang != Locale.CHINESE.language) {
+                    Locale.CHINESE.language
+                } else Locale.getDefault().language
+            }
+
+            return field
+        }
+
+    fun toggleLanguage() {
+        locale = if (localeEn == locale) localeZh else localeEn
+    }
 
     override fun getState(): P3cConfig {
         return this
@@ -51,8 +65,9 @@ class P3cConfig : PersistentStateComponent<P3cConfig> {
         XmlSerializerUtil.copyBean(state, this)
     }
 
+
     companion object {
-        val localeEn = "en"
-        val localeZh = "zh"
+        val localeEn = Locale.ENGLISH.language!!
+        val localeZh = Locale.CHINESE.language!!
     }
 }

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
@@ -43,7 +43,7 @@ class P3cConfig : PersistentStateComponent<P3cConfig> {
             if (field.isEmpty()) {
                 val lang = Locale.getDefault().language
                 return if (lang != Locale.ENGLISH.language && lang != Locale.CHINESE.language) {
-                    Locale.CHINESE.language
+                    Locale.ENGLISH.language
                 } else Locale.getDefault().language
             }
 

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/i18n/P3cBundle.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/i18n/P3cBundle.kt
@@ -29,7 +29,7 @@ import java.util.ResourceBundle
  * @date 2017/06/20
  */
 object P3cBundle {
-    val p3cConfig = P3cConfig::class.java.getService()
+    private val p3cConfig = P3cConfig::class.java.getService()
     private val resourceBundle = ResourceBundle.getBundle("messages.P3cBundle",
             Locale(p3cConfig.locale), I18nResources.XmlControl())
 

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/MapOrSetKeyShouldOverrideHashCodeEqualsInspection.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/MapOrSetKeyShouldOverrideHashCodeEqualsInspection.kt
@@ -171,16 +171,20 @@ class MapOrSetKeyShouldOverrideHashCodeEqualsInspection : BaseInspection, AliBas
 
     companion object {
 
+        private val skipJdkPackageJava = "java."
+        private val skipJdkPackageJavax = "javax."
+
         private fun redefineHashCodeEquals(psiType: PsiType): Boolean {
             if (psiType !is PsiClassType) {
                 return true
             }
-            val psiClass = psiType.resolve()
-            if (psiClass == null || psiClass.containingFile == null || psiClass is PsiTypeParameter
-                    || psiClass.isEnum || psiClass.isInterface) {
-                return true
-            }
-            if (psiClass.containingFile.fileType !is JavaFileType) {
+            val psiClass = psiType.resolve() ?: return false
+            val skip = psiClass.containingFile == null || psiClass is PsiTypeParameter
+                    || psiClass.isEnum || psiClass.isInterface
+                    || psiClass.containingFile.fileType !is JavaFileType
+                    || psiClass.qualifiedName?.startsWith(skipJdkPackageJava) ?: false
+                    || psiClass.qualifiedName?.startsWith(skipJdkPackageJavax) ?: false
+            if (skip) {
                 return true
             }
             val hashCodeMethods = psiClass.findMethodsByName(ObjectConstants.METHOD_NAME_HASHCODE, false)

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AliQuickFix.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AliQuickFix.kt
@@ -27,6 +27,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiLocalVariable
 import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiParameter
 
 /**
  *
@@ -48,7 +49,9 @@ interface AliQuickFix : LocalQuickFix {
 
         fun doQuickFix(newIdentifier: String, project: Project, psiIdentifier: PsiIdentifier) {
             val offset = psiIdentifier.textOffset
-            if (psiIdentifier.parent !is PsiMember && psiIdentifier.parent !is PsiLocalVariable) {
+            val cannotFix = psiIdentifier.parent !is PsiMember
+                    && !(psiIdentifier.parent is PsiLocalVariable || psiIdentifier.parent is PsiParameter)
+            if (cannotFix) {
                 return
             }
 


### PR DESCRIPTION
fix #149  
IDEA插件 函数定义中参数的命名可以检测到非驼峰并高亮，但不能快捷修改。

fix #60 
use Locale.default() for the initial language

fix #58 
do not check array and class starts with java. or javax.