### PR TITLE
实时监测功能切换选项改进

### DIFF
--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/ToggleProjectInspectionAction.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/ToggleProjectInspectionAction.kt
@@ -41,14 +41,15 @@ class ToggleProjectInspectionAction : AnAction() {
         val tools = Inspections.aliInspections(project) {
             it.tool is AliBaseInspection
         }
-        InspectionProfileService.toggleInspection(project, tools, smartFoxConfig.projectInspectionClosed)
-        smartFoxConfig.projectInspectionClosed = !smartFoxConfig.projectInspectionClosed
+        val closed = InspectionProfileService.isProjectInspectionClosed(project)
+        InspectionProfileService.toggleInspection(project, tools, closed)
     }
 
     override fun update(e: AnActionEvent?) {
         val project = e!!.project ?: return
         val smartFoxConfig = ServiceManager.getService(project, SmartFoxProjectConfig::class.java)
-        e.presentation.text = if (smartFoxConfig.projectInspectionClosed) {
+        val closed = InspectionProfileService.isProjectInspectionClosed(project)
+        e.presentation.text = if (closed) {
             e.presentation.icon = P3cIcons.PROJECT_INSPECTION_ON
             P3cBundle.getMessage("$textKey.open")
         } else {

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/ToggleProjectInspectionAction.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/action/ToggleProjectInspectionAction.kt
@@ -20,9 +20,12 @@ import com.alibaba.p3c.idea.compatible.inspection.Inspections
 import com.alibaba.p3c.idea.config.SmartFoxProjectConfig
 import com.alibaba.p3c.idea.i18n.P3cBundle
 import com.alibaba.p3c.idea.inspection.AliBaseInspection
+import com.intellij.codeInspection.ex.InspectionToolWrapper
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
 import icons.P3cIcons
 
 /**
@@ -38,16 +41,23 @@ class ToggleProjectInspectionAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val smartFoxConfig = ServiceManager.getService(project, SmartFoxProjectConfig::class.java)
-        val tools = Inspections.aliInspections(project) {
-            it.tool is AliBaseInspection
-        }
         val closed = InspectionProfileService.isProjectInspectionClosed(project)
-        InspectionProfileService.toggleInspection(project, tools, closed)
+        val tools = if (closed) {
+            if(smartFoxConfig.lastCloseAliInspectionTools.isNotEmpty()) {
+                smartFoxConfig.lastCloseAliInspectionTools
+            } else {
+                Inspections.aliInspections(project) { it.tool is AliBaseInspection }
+                        .map { it.tool.shortName }
+            }
+        } else {
+            getEnabledTools(project)
+        }
+        smartFoxConfig.lastCloseAliInspectionTools = tools
+        InspectionProfileService.toggleInspectionWithName(project, tools, closed)
     }
 
     override fun update(e: AnActionEvent?) {
         val project = e!!.project ?: return
-        val smartFoxConfig = ServiceManager.getService(project, SmartFoxProjectConfig::class.java)
         val closed = InspectionProfileService.isProjectInspectionClosed(project)
         e.presentation.text = if (closed) {
             e.presentation.icon = P3cIcons.PROJECT_INSPECTION_ON
@@ -56,5 +66,12 @@ class ToggleProjectInspectionAction : AnAction() {
             e.presentation.icon = P3cIcons.PROJECT_INSPECTION_OFF
             P3cBundle.getMessage("$textKey.close")
         }
+    }
+
+    private fun getEnabledTools(project: Project): List<String> {
+        val profile = InspectionProfileService.getProjectInspectionProfile(project)
+        return Inspections.aliInspections(project) { it.tool is AliBaseInspection }
+                .filter { profile.getToolDefaultState(it.tool.shortName, project).isEnabled }
+                .map { it.tool.shortName }
     }
 }

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/compatible/inspection/InspectionProfileService.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/compatible/inspection/InspectionProfileService.kt
@@ -15,6 +15,7 @@
  */
 package com.alibaba.p3c.idea.compatible.inspection
 
+import com.alibaba.p3c.idea.inspection.AliBaseInspection
 import com.alibaba.smartfox.idea.common.util.PluginVersions
 import com.google.common.collect.Sets
 import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
@@ -112,5 +113,15 @@ object InspectionProfileService {
 
     fun getProjectInspectionProfile(project: Project): InspectionProfileImpl {
         return InspectionProjectProfileManager.getInstance(project).inspectionProfile as InspectionProfileImpl
+    }
+
+    fun isProjectInspectionClosed(project: Project): Boolean {
+        val profile = getProjectInspectionProfile(project)
+        val tools = Inspections.aliInspections(project) {
+            it.tool is AliBaseInspection
+        }
+        return !tools.any {
+            profile.getToolDefaultState(it.tool.shortName, project).isEnabled
+        }
     }
 }

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/SmartFoxProjectConfig.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/SmartFoxProjectConfig.kt
@@ -33,6 +33,8 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class SmartFoxProjectConfig : PersistentStateComponent<SmartFoxProjectConfig> {
     var inspectionProfileModifiedSet = Sets.newHashSet<String>()!!
 
+    var lastCloseAliInspectionTools : List<String> = ArrayList()
+
     override fun getState(): SmartFoxProjectConfig? {
         return this
     }

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/SmartFoxProjectConfig.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/SmartFoxProjectConfig.kt
@@ -33,8 +33,6 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class SmartFoxProjectConfig : PersistentStateComponent<SmartFoxProjectConfig> {
     var inspectionProfileModifiedSet = Sets.newHashSet<String>()!!
 
-    var projectInspectionClosed = false
-
     override fun getState(): SmartFoxProjectConfig? {
         return this
     }


### PR DESCRIPTION
修改功能：
- 保证Setting - Editor - Inspections - Ali-Check改变与打开/关闭实时检测功能选项一直。修改前，如果手动在Setting - Editor - Inspections - Ali-Check关闭inspection后“关闭实时检测功能”不会切换为“打开实时检测功能”，尽管这时候其实检测已经关闭了，打开时也同样。修改后在Setting中改变后popupMenu的切换也能对应上当前状态。
-  当用户在Setting - Editor - Inspections - Ali-Check设置只使用部分检测功能时，通过popup menu打开检测和关闭检测前后的检测选项选择情况保持一致，即使暂时关闭检测重启后再次打开检测功能也能保证一致
