### PR TITLE
correct the typo for GAV term.

### DIFF
--- a/p3c-gitbook/本手册专有名词.md
+++ b/p3c-gitbook/本手册专有名词.md
@@ -1,6 +1,6 @@
 ## 附2：本手册专有名词
 1. POJO（Plain Ordinary Java Object）: 在本手册中，POJO专指只有setter / getter / toString的简单类，包括DO/DTO/BO/VO等。 
-2. GAV（GroupId、ArtifactctId、Version）: Maven坐标，是用来唯一标识jar包。 
+2. GAV（GroupId、ArtifactId、Version）: Maven坐标，是用来唯一标识jar包。
 3. OOP（Object Oriented Programming）: 本手册泛指类、对象的编程处理方式。 
 4. ORM（Object Relation Mapping）: 对象关系映射，对象领域模型与底层数据之间的转换，本文泛指iBATIS, mybatis等框架。 
 5. NPE（java.lang.NullPointerException）: 空指针异常。 


### PR DESCRIPTION
Simply correct a typo in the GAV term.