### PR TITLE
correct method name

### DIFF
--- a/p3c-gitbook/编程规约/集合处理.md
+++ b/p3c-gitbook/编程规约/集合处理.md
@@ -68,7 +68,7 @@ List list = Arrays.asList(str);
 <br><span style="color:orange">说明</span>：HashMap使用HashMap(int initialCapacity) 初始化， 
 <br><span style="color:green">正例</span>：initialCapacity = (需要存储的元素个数 / 负载因子) + 1。注意负载因子（即loader factor）默认为0.75，如果暂时无法确定初始值大小，请设置为16（即默认值）。 <br><span style="color:red">反例</span>：HashMap需要放置1024个元素，由于没有设置容量初始大小，随着元素不断增加，容量7次被迫扩大，resize需要重建hash表，严重影响性能。 
 10. 【推荐】使用entrySet遍历Map类集合KV，而不是keySet方式进行遍历。 
-<br><span style="color:orange">说明</span>：keySet其实是遍历了2次，一次是转为Iterator对象，另一次是从hashMap中取出key所对应的value。而entrySet只是遍历了一次就把key和value都放到了entry中，效率更高。如果是JDK8，使用Map.foreach方法。 
+<br><span style="color:orange">说明</span>：keySet其实是遍历了2次，一次是转为Iterator对象，另一次是从hashMap中取出key所对应的value。而entrySet只是遍历了一次就把key和value都放到了entry中，效率更高。如果是JDK8，使用Map.forEach方法。 
 <br><span style="color:green">正例</span>：values()返回的是V值集合，是一个list集合对象；keySet()返回的是K值集合，是一个Set集合对象；entrySet()返回的是K-V值组合集合。 
 11. 【推荐】高度注意Map类集合K/V能不能存储null值的情况，如下表格：
 


### PR DESCRIPTION
Considering that Java is case-sensitive, method name "forEach" is more accurate.