### PR TITLE
LowerCamelCaseVariableNamingRule 和 StringConcatRule

### DIFF
--- a/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
+++ b/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
@@ -140,23 +140,7 @@ public interface BizConstants {
         <expected-problems>0</expected-problems>
         <code-ref id="LowerCamelCaseVariableNamingRuleTest8" />
     </test-code>
-
-    <code-fragment id="LowerCamelCaseVariableNamingRuleTest8">
-        <![CDATA[
-        public @interface TYPE {
-            int DO_NO_THING = 0;
-            int DO_ONE_START_TO_END_ROUTE = 1;
-            int DO_ONE_CAR_TO_START_ROUTE = 2;
-            int DO_TWO_ROUTE = 3;
-        }
-    ]]>
-    </code-fragment>
-    <test-code>
-        <description>Variable name should be lowerCamelCase8</description>
-        <expected-problems>0</expected-problems>
-        <code-ref id="LowerCamelCaseVariableNamingRuleTest8" />
-    </test-code>
-
+    
     <code-fragment id="LowerCamelCaseVariableNamingRuleTest9">
         <![CDATA[
         @Document

--- a/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/oop/xml/StringConcatRule.xml
+++ b/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/oop/xml/StringConcatRule.xml
@@ -104,7 +104,7 @@
 		<code-ref id="assign-variable-out-of-loop" />
 	</test-code>
 
-	======================================================================
+	<!-- ====================================================================== -->
 	<code-fragment id="assign-variable-in-loop">
 		<![CDATA[
 	import java.util.List;


### PR DESCRIPTION

resolved  #458 

```
    LowerCamelCaseVariableNamingRule: 删除重复的LowerCamelCaseVariableNamingRuleTest8;
    StringConcatRule: line130 注释掉  ======================================================================
```