### PR TITLE
问题：lowerCamel变量命名匹配有误

### DIFF
--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/LowerCamelCaseVariableNamingRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/LowerCamelCaseVariableNamingRule.java
@@ -19,8 +19,8 @@ import java.util.regex.Pattern;
 
 import com.alibaba.p3c.pmd.I18nResources;
 import com.alibaba.p3c.pmd.lang.java.rule.AbstractAliRule;
+import com.alibaba.p3c.pmd.lang.java.util.StringAndCharConstants;
 import com.alibaba.p3c.pmd.lang.java.util.ViolationUtils;
-
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
@@ -38,10 +38,14 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 public class LowerCamelCaseVariableNamingRule extends AbstractAliRule {
 
     private static final String MESSAGE_KEY_PREFIX = "java.naming.LowerCamelCaseVariableNamingRule.violation.msg";
-    private Pattern pattern = Pattern.compile("^[a-z|$][a-z0-9]*([A-Z][a-z0-9]*)*(DO|DTO|VO|DAO)?$");
+    private Pattern pattern = Pattern.compile("^[a-z][a-z0-9]*([A-Z][a-z0-9]+)*(DO|DTO|VO|DAO)?$");
 
     @Override
     public Object visit(final ASTVariableDeclaratorId node, Object data) {
+        //避免与 AvoidStartWithDollarAndUnderLineNamingRule 重复判断(例: $myTest)
+        if (variableNamingStartOrEndWithDollarAndUnderLine(node.getImage())) {
+            return super.visit(node, data);
+        }
         // Constant named does not apply to this rule
         ASTTypeDeclaration typeDeclaration = node.getFirstParentOfType(ASTTypeDeclaration.class);
         Node jjtGetChild = typeDeclaration.jjtGetChild(0);
@@ -65,9 +69,9 @@ public class LowerCamelCaseVariableNamingRule extends AbstractAliRule {
     }
 
     @Override
-
     public Object visit(ASTMethodDeclarator node, Object data) {
-        if (!(pattern.matcher(node.getImage()).matches())) {
+        if (!variableNamingStartOrEndWithDollarAndUnderLine(node.getImage())
+            && !(pattern.matcher(node.getImage()).matches())) {
             ViolationUtils.addViolationWithPrecisePosition(this, node, data,
                 I18nResources.getMessage(MESSAGE_KEY_PREFIX + ".method", node.getImage()));
         }
@@ -78,5 +82,12 @@ public class LowerCamelCaseVariableNamingRule extends AbstractAliRule {
     public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
         //对所有注解内的内容不做检查
         return null;
+    }
+
+    private boolean variableNamingStartOrEndWithDollarAndUnderLine(String variable) {
+        return variable.startsWith(StringAndCharConstants.DOLLAR)
+                || variable.startsWith(StringAndCharConstants.UNDERSCORE)
+                || variable.endsWith(StringAndCharConstants.DOLLAR)
+                || variable.endsWith(StringAndCharConstants.UNDERSCORE);
     }
 }

--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/LowerCamelCaseVariableNamingRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/LowerCamelCaseVariableNamingRule.java
@@ -86,8 +86,6 @@ public class LowerCamelCaseVariableNamingRule extends AbstractAliRule {
 
     private boolean variableNamingStartOrEndWithDollarAndUnderLine(String variable) {
         return variable.startsWith(StringAndCharConstants.DOLLAR)
-                || variable.startsWith(StringAndCharConstants.UNDERSCORE)
-                || variable.endsWith(StringAndCharConstants.DOLLAR)
-                || variable.endsWith(StringAndCharConstants.UNDERSCORE);
+                || variable.startsWith(StringAndCharConstants.UNDERSCORE);
     }
 }

--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/util/StringAndCharConstants.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/util/StringAndCharConstants.java
@@ -26,4 +26,6 @@ public final class StringAndCharConstants {
     }
 
     public static final char DOT = '.';
+    public static final String DOLLAR = "$";
+    public static final String UNDERSCORE = "_";
 }

--- a/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
+++ b/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
@@ -201,8 +201,6 @@ public interface BizConstants {
             public void test(){
                 String $myName = "zhangsan";
                 int _myAge = 18;
-                String myHome$ = "beijing";
-                boolean flag_ = true;
             }
         }
     ]]>

--- a/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
+++ b/p3c-pmd/src/test/resources/com/alibaba/p3c/pmd/lang/java/rule/naming/xml/LowerCamelCaseVariableNamingRule.xml
@@ -13,9 +13,9 @@
     </code-fragment>
     <test-code>
         <description>Variable name should be lowerCamelCase</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
         <code-ref id="LowerCamelCaseVariableNamingRuleTest" />
-        <expected-linenumbers>3</expected-linenumbers>
+        <expected-linenumbers>2,3</expected-linenumbers>
     </test-code>
 
     <code-fragment id="LowerCamelCaseVariableNamingRuleTest1">
@@ -116,7 +116,7 @@ public interface BizConstants {
      public class MockTest{
         @Mock
         void $clinit(){}
-     }   
+     }
     ]]>
     </code-fragment>
     <test-code>
@@ -194,6 +194,22 @@ public interface BizConstants {
         <expected-problems>4</expected-problems>
         <code-ref id="LowerCamelCaseVariableNamingRuleTest10" />
     </test-code>
+
+    <code-fragment id="VariableNamingStartOrEndWithDollarAndUnderLine">
+        <![CDATA[
+        public class Example {
+            public void test(){
+                String $myName = "zhangsan";
+                int _myAge = 18;
+                String myHome$ = "beijing";
+                boolean flag_ = true;
+            }
+        }
+    ]]>
+    </code-fragment>
+    <test-code>
+        <description>Variable Naming Start Or End With Dollar And UnderLine</description>
+        <expected-problems>0</expected-problems>
+        <code-ref id="VariableNamingStartOrEndWithDollarAndUnderLine" />
+    </test-code>
 </test-data>
-
-


### PR DESCRIPTION
myNAME匹配有误、$name在编码规约中明确指出是反例