### PR TITLE
修正日期格式化字符串 y 和 Y 的使用示例

### DIFF
--- a/p3c-pmd/src/main/resources/rulesets/java/ali-other.xml
+++ b/p3c-pmd/src/main/resources/rulesets/java/ali-other.xml
@@ -95,13 +95,13 @@ Positive example:
         <example>
             <![CDATA[
 Negative example:
-    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    SimpleDateFormat format = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss");
  ]]>
         </example>
         <example>
             <![CDATA[
 Positive example:
-        SimpleDateFormat format = new SimpleDateFormat("YYYY-mm-dd HH:mm:ss");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-mm-dd HH:mm:ss");
 ]]>
         </example>
     </rule>


### PR DESCRIPTION
修正日期格式化字符串 y 和 Y 的使用示例，yyyy 应为 Positive example。
![image](https://user-images.githubusercontent.com/10843158/61576817-37c59480-ab11-11e9-84d2-ff9cbf31985f.png)
