### PR TITLE
修复 PackageNamingRule's message中英文不一致问题

### DIFF
--- a/p3c-pmd/src/main/resources/messages_en.xml
+++ b/p3c-pmd/src/main/resources/messages_en.xml
@@ -96,7 +96,7 @@
         <![CDATA[All Service and DAO classes must be interface based on SOA principle. Implementation class names should be ended with Impl]]>
     </entry>
     <entry key="java.naming.PackageNamingRule.rule.msg">
-        <![CDATA[All Service and DAO classes must be interface based on SOA principle. Implementation class names]]>
+        <![CDATA[ Package should be named in lowercase characters. There should be only one English word after each dot. Package names are always in singular format while class name can be in plural format if necessary.]]>
     </entry>
     <entry key="java.naming.BooleanPropertyShouldNotStartWithIsRule.rule.msg">
         <![CDATA[Do not add 'is' as prefix while defining Boolean variable, since it may cause a serialization exception in some Java Frameworks]]>


### PR DESCRIPTION
修复PackageNamingRule's message规则描述中英文不一致问题

在p3c-pmd/src/main/resources/messages_en.xml中：

```xml
    <entry key="java.naming.PackageNamingRule.rule.msg">
        <![CDATA[All Service and DAO classes must be interface based on SOA principle. Implementation class names]]>
    </entry>
```
英文规则描述的为soa的相关规则，非包命名的规则。
应该为：
```xml

    <entry key="java.naming.PackageNamingRule.rule.msg">
        <![CDATA[ Package should be named in lowercase characters. There should be only one English word after each dot. Package names are always in singular format while class name can be in plural format if necessary.]]>
    </entry>

```
