### PR TITLE
添加两个规则

### DIFF
--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/oop/VarargsParameterRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/oop/VarargsParameterRule.java
@@ -1,0 +1,44 @@
+package com.alibaba.p3c.pmd.lang.java.rule.oop;
+
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.alibaba.p3c.pmd.I18nResources;
+import com.alibaba.p3c.pmd.lang.AbstractXpathRule;
+import com.alibaba.p3c.pmd.lang.java.util.ViolationUtils;
+import net.sourceforge.pmd.lang.ast.Node;
+
+/**
+ * [Mandatory]
+ *
+ * @author leonard99559
+ * @date 2019/10/16
+ */
+public class VarargsParameterRule extends AbstractXpathRule {
+    private static final String XPATH = "//FormalParameter[@Varargs = 'true' and ./Type[@TypeImage = 'Object']]";
+
+    public VarargsParameterRule() {
+        setXPath(XPATH);
+    }
+
+    @Override
+    public void addViolation(Object data, Node node, String arg) {
+        ViolationUtils.addViolationWithPrecisePosition(this, node, data,
+                I18nResources.getMessage("java.oop.VarargsParameterRule.rule.msg",
+                        node.getImage()));
+    }
+
+}

--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/set/EqualsHashCodeRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/set/EqualsHashCodeRule.java
@@ -1,0 +1,51 @@
+package com.alibaba.p3c.pmd.lang.java.rule.set;
+
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.alibaba.p3c.pmd.lang.java.rule.AbstractAliRule;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import org.jaxen.JaxenException;
+
+import java.util.List;
+
+/**
+ * [Mendatory] Equals method must be with hashCode() method.
+ *
+ * @author leonard99559
+ * @date 2019/10/16
+ */
+public class EqualsHashCodeRule extends AbstractAliRule {
+
+    @Override
+    public Object visit(ASTCompilationUnit rootNode, Object data) {
+
+        try {
+            List<Node> nodeList = rootNode.findChildNodesWithXPath(
+                    "//ClassOrInterfaceBodyDeclaration[./Annotation[@AnnotationName = 'Override']]" +
+                            "//MethodDeclaration[@MethodName = 'hashCode' or @MethodName = 'equals']");
+            if (nodeList.size() == 1) {
+                addViolationWithMessage(data, nodeList.get(0),
+                        "java.set.EqualsHashCodeRule.rule.msg");
+            }
+        } catch (JaxenException e) {
+            e.printStackTrace();
+        }
+        return super.visit(rootNode, data);
+    }
+
+}

--- a/p3c-pmd/src/main/resources/messages.xml
+++ b/p3c-pmd/src/main/resources/messages.xml
@@ -260,6 +260,9 @@
     <entry key="java.set.UnsupportedExceptionWithModifyAsListRule.rule.msg">
         <![CDATA[ 使用工具类Arrays.asList()把数组转换成集合时，不能使用其修改集合相关的方法，它的add/remove/clear方法会抛出UnsupportedOperationException异常。 ]]>
     </entry>
+    <entry key="java.set.EqualsHashCodeRule.rule.msg">
+        <![CDATA[只要覆写equals，就必须覆写hashCode。]]>
+    </entry>
     <!-- constant -->
     <entry key="java.constant.UndefineMagicConstantRule.violation.msg">
         <![CDATA[ 魔法值【%s】]]>
@@ -348,6 +351,9 @@
         <![CDATA[说明：BigDecimal(double)存在精度损失风险，在精确计算或值比较的场景中可能会导致业务逻辑异常。]]>
     </entry>
 
+    <entry key="java.oop.VarargsParameterRule.rule.msg">
+        <![CDATA[相同参数类型，相同业务含义，才可以使用 Java 的可变参数，避免使用 Object。]]>
+    </entry>
     <!-- comment -->
     <entry key="java.comment.CommentsMustBeJavadocFormatRule.rule.msg">
         <![CDATA[类、类属性、类方法的注释必须使用javadoc规范，使用/**内容*/格式，不得使用//xxx方式和/*xxx*/方式。]]>

--- a/p3c-pmd/src/main/resources/messages_en.xml
+++ b/p3c-pmd/src/main/resources/messages_en.xml
@@ -262,6 +262,9 @@ Note: Below are the problems created by usage of Executors for thread pool creat
     <entry key="java.set.UnsupportedExceptionWithModifyAsListRule.rule.msg">
         <![CDATA[Do not use methods which will modify the list after using Arrays.asList to convert array to list, otherwise methods like add/remove/clear will throw UnsupportedOperationException. ]]>
     </entry>
+    <entry key="java.set.EqualsHashCodeRule.rule.msg">
+        <![CDATA[Equals method must be with hashCode() method.]]>
+    </entry>
     <!-- constant -->
     <entry key="java.constant.UndefineMagicConstantRule.violation.msg">
         <![CDATA[Magic value [%s] ]]>
@@ -347,6 +350,9 @@ Note: Below are the problems created by usage of Executors for thread pool creat
     </entry>
     <entry key="java.oop.BigDecimalAvoidDoubleConstructorRule.rule.msg.desc">
         <![CDATA[Note：Use the constructor BigDecimal(String) or valueOf method of BigDecimal. Inside valueOf the toString of Double is executed, which truncate the mantissa according to the precision of double.]]>
+    </entry>
+    <entry key="java.oop.VarargsParameterRule.rule.msg">
+        <![CDATA[Use detail Class for Varargs, do not use Object。]]>
     </entry>
 
     <!-- comment -->

--- a/p3c-pmd/src/main/resources/rulesets/java/ali-oop.xml
+++ b/p3c-pmd/src/main/resources/rulesets/java/ali-oop.xml
@@ -153,5 +153,17 @@ Positive example:
 ]]>
         </example>
     </rule>
+    <rule name="VarargsParameterRule" language="java"
+          message="java.oop.VarargsParameterRule.rule.msg"
+          class="com.alibaba.p3c.pmd.lang.java.rule.oop.VarargsParameterRule">
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+Negative example:
+   private void method(Param a, Param b, Object... objs) {
 
+   }
+         ]]>
+        </example>
+    </rule>
 </ruleset>

--- a/p3c-pmd/src/main/resources/rulesets/java/ali-set.xml
+++ b/p3c-pmd/src/main/resources/rulesets/java/ali-set.xml
@@ -129,5 +129,23 @@ Negative example:
          ]]>
       </example>
     </rule>
+    <rule name="EqualsHashCodeRule" language="java"
+          message="java.set.EqualsHashCodeRule.rule.msg"
+          class="com.alibaba.p3c.pmd.lang.java.rule.set.EqualsHashCodeRule">
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+Positive example:
+    @Override
+    public int hashCode() {
+        return ...;
+    }
 
+    @Override
+    public boolean equals(Object obj) {
+        return ...;
+    }
+         ]]>
+        </example>
+    </rule>
 </ruleset>


### PR DESCRIPTION
1. 只要重写equals，就必须重写hashCode
2. 相同参数类型，相同业务含义，才可以使用Java的可变参数，避免使用Object