### PR TITLE
Compatible with single letter camel naming

### DIFF
--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
@@ -34,7 +34,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 public class ClassNamingShouldBeCamelRule extends AbstractAliRule {
 
     private static final Pattern PATTERN
-        = Pattern.compile("^I?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO))?$");
+        = Pattern.compile("^[A-Z]?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO))?$");
 
     private static final List<String> CLASS_NAMING_WHITE_LIST = NameListConfig.NAME_LIST_SERVICE.getNameList(
         ClassNamingShouldBeCamelRule.class.getSimpleName(), "CLASS_NAMING_WHITE_LIST");


### PR DESCRIPTION
There are many Single-Letter-Camel Naming in OpenSource project, etc:HBase,XStream,BTrace,TEngine.

My commit modified the regex so that classnames can be named starting with any single capital letter