### PR TITLE
fix: @date不一个有效的javadoc tag, 去除其@并调到@author上面

### DIFF
--- a/p3c-formatter/eclipse-codetemplate.xml
+++ b/p3c-formatter/eclipse-codetemplate.xml
@@ -5,8 +5,8 @@
  */</template><template autoinsert="true" context="constructorcomment_context" deleted="false" description="Comment for created constructors" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.constructorcomment" name="constructorcomment">/**
  * ${tags}
  */</template><template autoinsert="true" context="filecomment_context" deleted="false" description="Comment for created Java files" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.filecomment" name="filecomment"/><template autoinsert="true" context="typecomment_context" deleted="false" description="Comment for created types" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.typecomment" name="typecomment">/**
+ * date：${currentDate:date('YYYY/MM/dd')}
  * @author ${user}
- * @date ${currentDate:date('YYYY/MM/dd')}
  */</template><template autoinsert="true" context="fieldcomment_context" deleted="false" description="Comment for fields" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.fieldcomment" name="fieldcomment">/**
  *
  */</template><template autoinsert="true" context="methodcomment_context" deleted="false" description="Comment for non-overriding methods" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.methodcomment" name="methodcomment">/**


### PR DESCRIPTION
eclipse-codetemplate.xml中@date不一个有效的javadoc tag
否则在java8下生成javadoc 时会报错