### PR TITLE
fix: rule of BigDecimalAvoidDoubleConstructorRule description wrong key

### DIFF
--- a/p3c-pmd/src/main/resources/rulesets/java/ali-oop.xml
+++ b/p3c-pmd/src/main/resources/rulesets/java/ali-oop.xml
@@ -136,7 +136,7 @@ Positive example:
           language="java"
           message="java.oop.BigDecimalAvoidDoubleConstructorRule.rule.msg"
           class="com.alibaba.p3c.pmd.lang.java.rule.oop.BigDecimalAvoidDoubleConstructorRule">
-        <description>java.oop.StringConcatRule.rule.msg.desc</description>
+        <description>java.oop.BigDecimalAvoidDoubleConstructorRule.rule.msg.desc</description>
         <priority>3</priority>
 
         <example>


### PR DESCRIPTION
BigDecimalAvoidDoubleConstructorRule uses the wrong description key

