### PR TITLE
feat : 修复 java.naming.ClassNamingShouldBeCamelRule.rule.msg 中英文本不一致问题。

### DIFF
--- a/p3c-pmd/src/main/resources/messages_en.xml
+++ b/p3c-pmd/src/main/resources/messages_en.xml
@@ -72,7 +72,7 @@
         <![CDATA[iBatis built in queryForList(String statementName, int start, int size) is not recommended]]>
     </entry>
     <entry key="java.naming.ClassNamingShouldBeCamelRule.rule.msg">
-        <![CDATA[Class names should be nouns in UpperCamelCase except domain models: DO, BO, DTO, VO, etc]]>
+        <![CDATA[Class names should be nouns in UpperCamelCase except domain models: DO, BO, DTO, VO, DAO, etc]]>
     </entry>
     <entry key="java.naming.AbstractClassShouldStartWithAbstractNamingRule.rule.msg">
         <![CDATA[Abstract class names must start with Abstract or Base]]>


### PR DESCRIPTION
As shown in the following code：

messages.xml
```
<entry key="java.naming.ClassNamingShouldBeCamelRule.rule.msg">
    <![CDATA[类名使用UpperCamelCase风格，必须遵从驼峰形式，但以下情形例外：（领域模型的相关命名）DO / BO / DTO / VO / DAO]]>
</entry>
```

messages_en.xml
```
<entry key="java.naming.ClassNamingShouldBeCamelRule.rule.msg">
    <![CDATA[Class names should be nouns in UpperCamelCase except domain models: DO, BO, DTO, VO, etc]]>
</entry>
```

so，I want to fix a mistake：

```
<entry key="java.naming.ClassNamingShouldBeCamelRule.rule.msg">
    <![CDATA[Class names should be nouns in UpperCamelCase except domain models: DO, BO, DTO, VO, DAO, etc]]>
</entry>
```