### PR TITLE
fix(Plugin Xml): Fix className when registe component

### DIFF
--- a/idea-plugin/p3c-idea/src/main/resources/META-INF/p3c.xml
+++ b/idea-plugin/p3c-idea/src/main/resources/META-INF/p3c.xml
@@ -1,8 +1,7 @@
 <idea-plugin>
     <application-components>
         <component>
-            <implementation-class>com.alibaba.p3c.idea.component.CommonSettingsApplicationComponent
-            </implementation-class>
+            <implementation-class>com.alibaba.p3c.idea.component.CommonSettingsApplicationComponent</implementation-class>
         </component>
     </application-components>
     <project-components>


### PR DESCRIPTION
配置中类名换行了，导致 2021.2 中注册 component 时正确加载类
![image](https://user-images.githubusercontent.com/29007752/121487079-50d8d680-ca04-11eb-9972-d9e729eb203a.png)
![image](https://user-images.githubusercontent.com/29007752/121487303-8a114680-ca04-11eb-87f1-19b0e1957a6e.png)

