### PR TITLE
fix(Plugin Xml): Fix className when register component

### DIFF
--- a/idea-plugin/p3c-idea/src/main/resources/META-INF/p3c.xml
+++ b/idea-plugin/p3c-idea/src/main/resources/META-INF/p3c.xml
@@ -1,8 +1,7 @@
 <idea-plugin>
     <application-components>
         <component>
-            <implementation-class>com.alibaba.p3c.idea.component.CommonSettingsApplicationComponent
-            </implementation-class>
+            <implementation-class>com.alibaba.p3c.idea.component.CommonSettingsApplicationComponent</implementation-class>
         </component>
     </application-components>
     <project-components>


### PR DESCRIPTION
配置中类名换行了，导致 2021.2 中注册 component 时不能正确加载类
![image](https://user-images.githubusercontent.com/29007752/121488481-b083b180-ca05-11eb-8b72-c94179368f28.png)
![image](https://user-images.githubusercontent.com/29007752/121488630-d315ca80-ca05-11eb-99fc-a12d2bba0169.png)

