### PR TITLE
update intellij plugin version to 12

### DIFF
--- a/idea-plugin/p3c-common/build.gradle
+++ b/idea-plugin/p3c-common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version '0.4.5'
+    id "org.jetbrains.intellij" version '0.4.12'
 }
 apply plugin: 'kotlin'
 apply plugin: 'idea'

--- a/idea-plugin/p3c-idea/build.gradle
+++ b/idea-plugin/p3c-idea/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version '0.4.5'
+    id "org.jetbrains.intellij" version '0.4.12'
 }
 apply plugin: 'kotlin'
 apply plugin: 'idea'


### PR DESCRIPTION
old intellij plugin 0.4.5 can't install 
<img width="1757" alt="image" src="https://user-images.githubusercontent.com/48286053/167118563-fa1dc9d4-9e83-43c2-b73b-265c031d6a89.png">

update to 0.4.12 help install 