### PR TITLE
[Issue-572] update class name check rule for Ignore MybatisGenerator  created *.mapper class

### DIFF
--- a/idea-plugin/p3c-common/build.gradle
+++ b/idea-plugin/p3c-common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version '0.7.3'
+    id "org.jetbrains.intellij" version '0.4.5'
 }
 apply plugin: 'kotlin'
 apply plugin: 'idea'

--- a/idea-plugin/p3c-common/build.gradle
+++ b/idea-plugin/p3c-common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version '0.4.5'
+    id "org.jetbrains.intellij" version '0.7.3'
 }
 apply plugin: 'kotlin'
 apply plugin: 'idea'

--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
@@ -34,7 +34,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 public class ClassNamingShouldBeCamelRule extends AbstractAliRule {
 
     private static final Pattern PATTERN
-        = Pattern.compile("^I?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO))?$");
+        = Pattern.compile("^I?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO｜Mapper))?$");
 
     private static final List<String> CLASS_NAMING_WHITE_LIST = NameListConfig.NAME_LIST_SERVICE.getNameList(
         ClassNamingShouldBeCamelRule.class.getSimpleName(), "CLASS_NAMING_WHITE_LIST");

--- a/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
+++ b/p3c-pmd/src/main/java/com/alibaba/p3c/pmd/lang/java/rule/naming/ClassNamingShouldBeCamelRule.java
@@ -34,7 +34,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 public class ClassNamingShouldBeCamelRule extends AbstractAliRule {
 
     private static final Pattern PATTERN
-        = Pattern.compile("^I?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO｜Mapper))?$");
+        = Pattern.compile("^I?([A-Z][a-z0-9]+)+(([A-Z])|(DO|DTO|VO|DAO|BO|DAOImpl|YunOS|AO|PO｜DOMapper))?$");
 
     private static final List<String> CLASS_NAMING_WHITE_LIST = NameListConfig.NAME_LIST_SERVICE.getNameList(
         ClassNamingShouldBeCamelRule.class.getSimpleName(), "CLASS_NAMING_WHITE_LIST");


### PR DESCRIPTION
MybatisGenerator生成的Mapper 类名称中包含DOMapper 会被标记为非规范，增加忽略校验规则