### PR TITLE
修复当缺少 @Override 时 IndexOutOfBoundException 报错

### DIFF
--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/AliMissingOverrideAnnotationInspection.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/AliMissingOverrideAnnotationInspection.kt
@@ -77,7 +77,6 @@ class AliMissingOverrideAnnotationInspection : MissingOverrideAnnotationInspecti
     override fun buildVisitor(): BaseInspectionVisitor = MissingOverrideAnnotationVisitor()
 
     private inner class MissingOverrideAnnotationVisitor : BaseInspectionVisitor() {
-
         override fun visitMethod(method: PsiMethod) {
             if (method.nameIdentifier == null) {
                 return
@@ -103,7 +102,8 @@ class AliMissingOverrideAnnotationInspection : MissingOverrideAnnotationInspecti
                     MethodUtils.isToString(method))) {
                 return
             }
-            registerMethodError(method)
+            // 兼容高版本 buildFix 参数结构
+            registerMethodError(method, method, false, false)
         }
 
         private fun hasOverrideAnnotation(element: PsiModifierListOwner): Boolean {


### PR DESCRIPTION
高版本的 IDEA 的 MissingOverrideAnnotationInspection 里的 infos 值修改了添加了额外的参数判断是否要在父类方法上报错