### PR TITLE
修复启动时报错 do not use constructor injection

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -34,5 +34,9 @@ allprojects {
         compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
         testCompile group: 'junit', name: 'junit', version: '4.11'
     }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions.jvmTarget = "1.8"
+    }
 }
 

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/component/AliProjectComponent.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/component/AliProjectComponent.kt
@@ -41,8 +41,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
  * @date 2016/12/13
  */
 class AliProjectComponent(
-    private val project: Project,
-    val p3cConfig: P3cConfig
+    private val project: Project
 ) : AliBaseProjectComponent {
     private val listener: VirtualFileListener
     private val javaExtension = ".java"
@@ -55,6 +54,7 @@ class AliProjectComponent(
     private val fileContexts = ConcurrentHashMap<String, FileContext>()
 
     init {
+        val p3cConfig = P3cConfig.getInstance()
         listener = object : VirtualFileAdapter() {
             override fun contentsChanged(event: VirtualFileEvent) {
                 val path = getFilePath(event) ?: return
@@ -98,6 +98,7 @@ class AliProjectComponent(
     }
 
     override fun initComponent() {
+        val p3cConfig = P3cConfig.getInstance()
         I18nResources.changeLanguage(p3cConfig.locale)
         val analyticsGroup = ActionManager.getInstance().getAction(analyticsGroupId)
         analyticsGroup.templatePresentation.text = P3cBundle.getMessage(analyticsGroupText)

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/config/P3cConfig.kt
@@ -18,6 +18,7 @@ package com.alibaba.p3c.idea.config
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import java.util.Locale
 
@@ -64,5 +65,8 @@ class P3cConfig : PersistentStateComponent<P3cConfig> {
     companion object {
         val localeEn = Locale.ENGLISH.language!!
         val localeZh = Locale.CHINESE.language!!
+
+        @JvmStatic
+        fun getInstance(): P3cConfig = service<P3cConfig>()
     }
 }


### PR DESCRIPTION
高版本的IDEA已经不推荐使用Component，推荐迁移到Service。
这里只是修改了Component参数通过service()获取P3cConfig来代替原来的构造方法注入