### PR TITLE
Fix ArrayIndexOutOfBoundsException in AliMissingOverrideAnnotationInspection

### DIFF
--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/AliMissingOverrideAnnotationInspection.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/inspection/standalone/AliMissingOverrideAnnotationInspection.kt
@@ -65,12 +65,20 @@ class AliMissingOverrideAnnotationInspection : MissingOverrideAnnotationInspecti
     override fun createOptionsPanel(): JComponent? = null
 
     override fun buildFix(vararg infos: Any): InspectionGadgetsFix? {
+        if (infos.isEmpty()) {
+            return null
+        }
         val fix = super.buildFix(*infos) ?: return null
         return DecorateInspectionGadgetsFix(fix,
             P3cBundle.getMessage("com.alibaba.p3c.idea.quickfix.standalone.AliMissingOverrideAnnotationInspection"))
     }
 
-    override fun manualBuildFix(psiElement: PsiElement, isOnTheFly: Boolean): LocalQuickFix? = buildFix(psiElement)
+    override fun manualBuildFix(psiElement: PsiElement, isOnTheFly: Boolean): LocalQuickFix? {
+        if (psiElement == null) {
+            return null
+        }
+        return buildFix(psiElement)
+    }
 
     override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevels.BLOCKER
 


### PR DESCRIPTION
Related to #999

Add checks for empty arrays in `AliMissingOverrideAnnotationInspection.kt` to prevent `ArrayIndexOutOfBoundsException`.

* Add a check for empty `infos` array before accessing elements in the `buildFix` method.
* Add a check for null `psiElement` before calling `buildFix` in the `manualBuildFix` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alibaba/p3c/issues/999?shareId=dec10e0e-51cf-437a-ab0d-fb5696c3e197).